### PR TITLE
fix: Follow changes to nvim-surround

### DIFF
--- a/lua/ns-textobject/textobj.lua
+++ b/lua/ns-textobject/textobj.lua
@@ -9,7 +9,7 @@ local textobj_map = require("ns-textobject.keymap").textobj_map
 ---@param mode "i"|"a" Inside or around
 ---@return table A table containing the start and end positions of the delimiters.
 local function get_nearest_selections(char, mode)
-    char = ns_utils.get_alias(char)
+    char = ns_config.get_alias(char)
 
     local chars = ns_config.get_opts().aliases[char] or { char }
     chars = type(chars) == "string" and { chars } or chars


### PR DESCRIPTION
`get_alias` moved from ns_utils to ns_config due to refactoring

https://github.com/kylechui/nvim-surround/commit/abccb2313b581c920b1117b60f91d00f0f469e17